### PR TITLE
Modify SWIM_SPEED instead of MOVEMENT_SPEED for flippers

### DIFF
--- a/src/main/java/pl/pabilo8/immersiveintelligence/common/items/armor/ItemIILightEngineerBoots.java
+++ b/src/main/java/pl/pabilo8/immersiveintelligence/common/items/armor/ItemIILightEngineerBoots.java
@@ -74,7 +74,7 @@ public class ItemIILightEngineerBoots extends ItemIIUpgradeableArmor implements 
 		{
 			if(ItemNBTHelper.hasKey(stack, "flippin"))
 			{
-				multimap.put(SharedMonsterAttributes.MOVEMENT_SPEED.getName(), new AttributeModifier(ARMOR_MODIFIERS[equipmentSlot.getIndex()], "Flippers", 4, 2));
+				multimap.put(EntityLivingBase.SWIM_SPEED.getName(), new AttributeModifier(ARMOR_MODIFIERS[equipmentSlot.getIndex()], "Flippers", 4, 2));
 			}
 			if(ItemNBTHelper.hasKey(stack, "rackets"))
 			{


### PR DESCRIPTION
Hi, I'm the maintainer of [Aqua Acrobatics](﻿https://github.com/Fuzss/aquaacrobatics), a mod which adds 1.13 swimming mechanics to 1.12.

Your flippers item modifies the MOVEMENT_SPEED attribute to increase the player's speed underwater, however, this is unreliable and doesn't work with my mod installed. I have adjusted the mod to use the Forge-provided SWIM_SPEED attribute instead. This seemed to still work without AA installed from a quick test, but I'm not sure if the behavior perfectly matches how MOVEMENT_SPEED worked before.

Note that in 1.16, adjusting the `generic.movement_speed` attribute also doesn't change the player's swimming speed, so I think the AA behavior is correct in this case.

Let me know if you have a better suggestion!

Related: Fuzss/aquaacrobatics#61
