### PR TITLE
Fixes erroneous display of projector names regarding skycrate multiblocks

### DIFF
--- a/src/main/resources/assets/immersiveintelligence/lang/en_us.lang
+++ b/src/main/resources/assets/immersiveintelligence/lang/en_us.lang
@@ -803,9 +803,9 @@ desc.immersiveintelligence.metal_multiblock1.chemical_painter.color.hsv.s=Satura
 desc.immersiveintelligence.metal_multiblock1.chemical_painter.color.hsv.v=Value
 desc.immersiveintelligence.metal_multiblock1.chemical_painter.color_copied=Color Copied!
 
-desc.immersiveengineering.info.multiblock.II:SkyCrateStation=SkyCrate Station
-desc.immersiveengineering.info.multiblock.II:SkyCartStation=SkyCart Station
-desc.immersiveengineering.info.multiblock.II:SkyCratePost=SkyCrate Post
+desc.immersiveengineering.info.multiblock.II:SkycrateStation=SkyCrate Station
+desc.immersiveengineering.info.multiblock.II:SkycartStation=SkyCart Station
+desc.immersiveengineering.info.multiblock.II:SkycratePost=SkyCrate Post
 desc.immersiveengineering.info.multiblock.II:Sawmill=Sawmill
 desc.immersiveengineering.info.multiblock.II:DataInputMachine=Data Input Machine
 desc.immersiveengineering.info.multiblock.II:ArithmeticLogicMachine=Arithmetic-Logic Machine

--- a/src/main/resources/assets/immersiveintelligence/lang/pl_pl.lang
+++ b/src/main/resources/assets/immersiveintelligence/lang/pl_pl.lang
@@ -333,8 +333,8 @@ tile.immersiveintelligence.metal_multiblock.minecart_packer.name=Kolejowa Maszyn
 
 tile.immersiveintelligence.metal_multiblock1.redstone_data_interface.name=Interfejs Redstone-Dane
 
-desc.immersiveengineering.info.multiblock.II:SkyCrateStation=Stacja SkyCrate
-desc.immersiveengineering.info.multiblock.II:SkyCratePost=Węzeł SkyCrate
+desc.immersiveengineering.info.multiblock.II:SkycrateStation=Stacja SkyCrate
+desc.immersiveengineering.info.multiblock.II:SkycratePost=Węzeł SkyCrate
 desc.immersiveengineering.info.multiblock.II:Sawmill=Krajzega
 desc.immersiveengineering.info.multiblock.II:DataInputMachine=Maszyna Wprowadzania Danych
 desc.immersiveengineering.info.multiblock.II:ArithmeticLogicMachine=Maszyna Arytmetyczno-Logiczna
@@ -995,7 +995,7 @@ tile.immersiveintelligence.metal_multiblock1.ammunition_filler.name=Ammunition F
 tile.immersiveintelligence.metal_multiblock1.ammunition_assembly.name=Ammunition Assembly
 tile.immersiveintelligence.metal_multiblock1.ammunition_workshop.name=Ammunition Workshop
 tile.immersiveintelligence.metal_multiblock1.chemical_painter.name=Chemical Painter
-desc.immersiveengineering.info.multiblock.II:SkyCartStation=SkyCart Station
+desc.immersiveengineering.info.multiblock.II:SkycartStation=SkyCart Station
 desc.immersiveengineering.info.multiblock.II:VehicleWorkshop=Vehicle Workshop
 desc.immersiveengineering.info.multiblock.II:FuelStation=Fuel Station
 desc.immersiveengineering.info.multiblock.II:AmmunitionFiller=Ammunition Filler

--- a/src/main/resources/assets/immersiveintelligence/lang/ru_ru.lang
+++ b/src/main/resources/assets/immersiveintelligence/lang/ru_ru.lang
@@ -340,8 +340,8 @@ tile.immersiveintelligence.metal_multiblock.minecart_packer.name=Рельсов�
 tile.immersiveintelligence.metal_multiblock1.redstone_data_interface.name=Интерфейс красный камень-данные
 
 
-desc.immersiveengineering.info.multiblock.II:SkyCrateStation=Фуникулёрная станция
-desc.immersiveengineering.info.multiblock.II:SkyCratePost=Фуникулёрный пост
+desc.immersiveengineering.info.multiblock.II:SkycrateStation=Фуникулёрная станция
+desc.immersiveengineering.info.multiblock.II:SkycratePost=Фуникулёрный пост
 desc.immersiveengineering.info.multiblock.II:Sawmill=Лесопилка
 desc.immersiveengineering.info.multiblock.II:DataInputMachine=Машина ввода данных
 desc.immersiveengineering.info.multiblock.II:ArithmeticLogicMachine=Арифметико-логическая машина

--- a/src/main/resources/assets/immersiveintelligence/lang/zh_cn.lang
+++ b/src/main/resources/assets/immersiveintelligence/lang/zh_cn.lang
@@ -753,9 +753,9 @@ desc.immersiveintelligence.metal_multiblock1.chemical_painter.color.hsv.s=Satura
 desc.immersiveintelligence.metal_multiblock1.chemical_painter.color.hsv.v=Value
 desc.immersiveintelligence.metal_multiblock1.chemical_painter.color_copied=色彩已复制!
 
-desc.immersiveengineering.info.multiblock.II:SkyCrateStation=飞箱索道站
-desc.immersiveengineering.info.multiblock.II:SkyCartStation=天车索道站
-desc.immersiveengineering.info.multiblock.II:SkyCratePost=索道中继点
+desc.immersiveengineering.info.multiblock.II:SkycrateStation=飞箱索道站
+desc.immersiveengineering.info.multiblock.II:SkycartStation=天车索道站
+desc.immersiveengineering.info.multiblock.II:SkycratePost=索道中继点
 desc.immersiveengineering.info.multiblock.II:Sawmill=锯木厂
 desc.immersiveengineering.info.multiblock.II:DataInputMachine=数据输入机
 desc.immersiveengineering.info.multiblock.II:ArithmeticLogicMachine=算术逻辑机


### PR DESCRIPTION
Within the language files, "Skycrate" was misspelled as "SkyCrate" which caused a mismatch with the description text. Updated for all current languages as it was a simple case change from C to c. Resolves #366.