### PR TITLE
Workaround for Skycrate deletion

### DIFF
--- a/src/main/java/pl/pabilo8/immersiveintelligence/common/entity/EntitySkyCrate.java
+++ b/src/main/java/pl/pabilo8/immersiveintelligence/common/entity/EntitySkyCrate.java
@@ -106,20 +106,21 @@ public class EntitySkyCrate extends Entity implements ITeslaEntity
 				}
 				if(!success)
 				{
-					if(crate.getItem() instanceof ItemBlock)
+					/* if(crate.getItem() instanceof ItemBlock)
 					{
 						ItemBlock b = (ItemBlock)crate.getItem();
-						EntityFallingBlock e = new EntityFallingBlock(world, (int)posX, (int)posY, (int)posX, b.getBlock().getDefaultState());
+						EntityFallingBlock e = new EntityFallingBlock(world, (int)posX, (int)posY-2, (int)posZ, b.getBlock().getDefaultState());
 						world.spawnEntity(e);
-						e.fallTime = -1;
 					}
 					else
 					{
 						Utils.dropStackAtPos(world, getPosition(), crate.copy());
-					}
-					Utils.dropStackAtPos(world, getPosition(), mount.copy());
+					} */
+					BlockPos ePos = getPosition();
+					BlockPos dropPos = new BlockPos(ePos.getX(), ePos.getY() - 2, ePos.getZ());
+					Utils.dropStackAtPos(world, dropPos, mount.copy());
+					Utils.dropStackAtPos(world, dropPos, crate.copy());
 					this.setDead();
-
 				}
 			}
 			else if(world.getTileEntity(getPosition()) instanceof ISkyCrateConnector)


### PR DESCRIPTION
Comments out not-working function to create a gravity block at entity location and instead drops crate as an item. Couldn't get the block drop method to work. There was a typo which I fixed, however, the falling crate block disappears when it hits the ground.

In addition to using the item drop method, the position is changed to be beneath the Skycrate post. If you want, you can modify line 120 to instead be -1; this would put it inside the Skycrate post collision when created, which you can pretend it is a sort of "explosion".

Resolves #367 

Showcase:
[Desktop 2024.10.23 - 19.37.33.01.webm](https://github.com/user-attachments/assets/bc92a68d-5577-4d6c-adfb-aa54b833e64b)
