### PR TITLE
Cleanup and repair of Logistics Category

### DIFF
--- a/src/main/java/pl/pabilo8/immersiveintelligence/client/manual/categories/IIManualCategoryLogistics.java
+++ b/src/main/java/pl/pabilo8/immersiveintelligence/client/manual/categories/IIManualCategoryLogistics.java
@@ -14,6 +14,7 @@ import pl.pabilo8.immersiveintelligence.common.block.rotary_device.BlockIIMechan
 import pl.pabilo8.immersiveintelligence.common.block.rotary_device.BlockIIMechanicalDevice1.IIBlockTypes_MechanicalDevice1;
 import pl.pabilo8.immersiveintelligence.common.item.ItemIIMinecart.Minecarts;
 import pl.pabilo8.immersiveintelligence.common.item.crafting.ItemIISawBlade.SawBlades;
+import pl.pabilo8.immersiveintelligence.common.item.mechanical.ItemIIMotorBelt.MotorBelt;
 import pl.pabilo8.immersiveintelligence.common.item.mechanical.ItemIIMotorGear.MotorGear;
 import pl.pabilo8.immersiveintelligence.common.util.IIReference;
 
@@ -86,8 +87,22 @@ public class IIManualCategoryLogistics extends IIManualCategory
 					IIContent.blockMechanicalConnector.getStack(IIBlockTypes_MechanicalConnector.STEEL_WHEEL)
 			))
 
-			.addSource("belt", getSourceForItem(
-					new ItemStack(IIContent.itemMotorBelt)))
+			.addSource("belt", getSourceForItems(
+					new ItemStack(IIContent.itemMotorBelt),
+					new ItemStack(IIContent.itemMotorBelt, 1, 1),
+					new ItemStack(IIContent.itemMotorBelt, 1, 2)
+			))
+			
+			/* .addSource("belt_items", getSourceForItems(
+					IIContent.itemMotorBelt.getStack(MotorBelt.CLOTH),
+					IIContent.itemMotorBelt.getStack(MotorBelt.STEEL),
+					IIContent.itemMotorBelt.getStack(MotorBelt.RUBBER)
+			)) */
+			
+			.addSource("belt_cloth", getSourceForItem(IIContent.itemMotorBelt.getStack(MotorBelt.CLOTH)))
+			.addSource("belt_steel", getSourceForItem(IIContent.itemMotorBelt.getStack(MotorBelt.STEEL)))
+			.addSource("belt_rubber", getSourceForItem(IIContent.itemMotorBelt.getStack(MotorBelt.RUBBER)))
+			
 			.addSource("gears", getSourceForItems(
 					IIContent.itemMotorGear.getStack(MotorGear.COPPER),
 					IIContent.itemMotorGear.getStack(MotorGear.BRASS),

--- a/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_logistics/chain_fences_and_gates.md
+++ b/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_logistics/chain_fences_and_gates.md
@@ -4,25 +4,33 @@ Three Meters and Growing!
 
 # fence_blocks
 |[crafting]{source:"fence_blocks"}|
-The chain fence can serve as a stylish, industrial looking barrier between factory zones. They offer low amounts of protection against a full scale invasion, but are enough to deter unwanted guests from your base. Available in many flavors.
+The chain fence can serve as a stylish, industrial looking barrier between factory zones. They offer low amounts of protection against a full scale invasion, but are enough to deter unwanted guests from your base. Available in several flavors!
+
+# multiblock_gates
+If standard size fence gates are too small for your needs, the **Engineering Department** offers large-scale fencing deployments fit for any industrial or military installation.<br>
+Fence gates can be upgraded to add razor wire on the top, and/or to offer [redstone wire](redstoneWires) connections, allowing remote control.
 
 # wooden_fence_gate
 |[multiblock]{mb:"II:WoodenFenceGate"}|
-The Wooden Fence Gate makes for a stylish entry point to your factory complex. They can be activated using redstone on the inward side. Like fences, many flavors are available.
+The Wooden Fence Gate makes for a stylish, [rustic] entry point to your factory complex. Form the multiblock by using a [hammer](introduction#introductionHammer) on the bottom light engineering blocks.
 
 # wooden_chain_fence_gate
 |[multiblock]{mb:"II:WoodenChainFenceGate"}|
-The Wooden Chain Fence Gate makes for a stylish entry point to your factory complex. They can be activated using redstone on the inward side. Like fences, many flavors are available.
+The Wooden Chain Fence Gate makes for a stylish, [chain-linked] entry point to your factory complex. Form the multiblock by using a [hammer](introduction#introductionHammer) on the bottom light engineering blocks.
+
 # steel_fence_gate
 |[multiblock]{mb:"II:SteelFenceGate"}|
-The Steel Fence Gate makes for a stylish entry point to your factory complex. They can be activated using redstone on the inward side. Like fences, many flavors are available.
+The Steel Fence Gate makes for a stylish, [formidable] entry point to your factory complex. Form the multiblock by using a [hammer](introduction#introductionHammer) on the bottom light engineering blocks.
+
 # steel_chain_fence_gate
 |[multiblock]{mb:"II:SteelChainFenceGate"}|
-The Steel Chain Fence Gate makes for a stylish entry point to your factory complex. They can be activated using redstone on the inward side. Like fences, many flavors are available.
+The Steel Chain Fence Gate makes for a stylish, [modern] entry point to your factory complex. Form the multiblock by using a [hammer](introduction#introductionHammer) on the bottom light engineering blocks.
+
 # aluminum_chain_fence_gate
 |[multiblock]{mb:"II:AluminiumFenceGate"}|
-The Aluminum Fence Gate makes for a stylish entry point to your factory complex. They can be activated using redstone on the inward side. Like fences, many flavors are available.
+The Aluminum Fence Gate makes for a stylish, [lightweight] entry point to your factory complex. Form the multiblock by using a [hammer](introduction#introductionHammer) on the bottom light engineering blocks.
+
 # aluminum_fence_gate
 |[multiblock]{mb:"II:AluminiumChainFenceGate"}|
-The Aluminum Chain Fence Gate makes for a stylish entry point to your factory complex. They can be activated using redstone on the inward side. Like fences, many flavors are available.
+The Aluminum Chain Fence Gate makes for a stylish, [unique] entry point to your factory complex. Form the multiblock by using a [hammer](introduction#introductionHammer) on the bottom light engineering blocks.
 

--- a/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_logistics/improved_capacitor_backpack.md
+++ b/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_logistics/improved_capacitor_backpack.md
@@ -4,7 +4,7 @@ Improved Capacitor Backpack
 
 # powerpack_1
 |[crafting]{source:"improved_capacitor"}|
-Improved Capacitor Backpack is a direct upgrade to the [Capacitor Backpack], with the main difference being more energy capacity and ability to be charged by [Tesla Coils](emplacement_weapons.md#tesla0).
+Improved Capacitor Backpack is a direct upgrade to the [Capacitor Backpack](powerpack), with the main difference being more energy capacity and ability to be charged by [Tesla Coils](emplacement_weapons.md#tesla0) or by [standing inside uninsulated wiring.]
 
 # powerpack_2
-Its wireless charging ability also makes the wearer immune to electric damage and removes the need of wearing the Faraday Suit. The Backpack's side sacks can be painted the same way as leather armor.
+Its wireless charging ability also makes the wearer [immune to electric damage] and removes the need of wearing the Faraday Suit. The Backpack's side sacks can be painted the same way as leather armor.

--- a/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_logistics/inserters.md
+++ b/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_logistics/inserters.md
@@ -4,10 +4,11 @@ No yellow this time!
 
 # intro
 |[item_display]{source:"inserters_full"}|
-The Precision Insertion Device, also known as the Inserter is a device used to transfer items from one inventory to another. Item inserters consists of an arm and motors for rotation and handling the item pickup. Fluid inserters use pipes and automatic valves. Inserters are able to take and output from and to any horizontal side desired.
+<br>The Precision Insertion Device, also known as the "Inserter," is a device used to transfer items from one inventory to another. Item Inserters consists of an arm and motors for rotation and handling the item pickup. Fluid Inserters use pipes and automatic valves. Inserters are able to take and output from and to any horizontal side desired.
 
 # intro_2
-The Inserter's sides can be configured with a hammer (sneak to set output). Inserters require electricity to run and data to tell them what to do.
+The Inserter's sides can be configured with a [hammer](introduction#introductionHammer). Right click to set an input. The device will turn to face that direction. Sneak to set an output. The output can be any of the non-input sides.<br>
+Inserters require electricity to run and [data](data_main.md) to tell them what to do.
 
 # basic_inserter
 |[crafting]{source:"inserter_basic"}|
@@ -16,29 +17,27 @@ The basic inserter is used for simple, but controlled item transfer. Made of bas
 # basic_commands_1
 |[data_variable]{type:"integer", direction:"in", letter:"e", name:"Expire after", description:"Optional. After what amount of operations should the task (request) end."}|
 |[data_variable]{type:"integer", direction:"in", letter:"t", name:"Item Take Amount", description:"Optional. Max amount of items the inserter will take per turn."}|
-|[data_variable]{type:"string", direction:"in", letter:"i", name:"Input Direction", description:"Optional Values:, north, east, south, west or Integer 0-2"}|
+|[data_variable]{type:"string", direction:"in", letter:"i", name:"Input Direction", description:"Optional Values: south, west, north, east, or Integer 0-3 (respectively)."}|
 
 # basic_commands_2
-|[data_variable]{type:"string", direction:"in", letter:"o", name:"Output Direction", description:"Optional Values: north, east, south, west, or Integer 0-2."}|
+|[data_variable]{type:"string", direction:"in", letter:"o", name:"Output Direction", description:"Optional Values: south, west, north, east, or Integer 0-3 (respectively)."}|
 |[data_variable]{type:"integer", direction:"in", letter:"1", name:"Input Distance", description:"Optional. Integer 1-2."}|
 |[data_variable]{type:"integer", direction:"in", letter:"0", name:"Output Distance", description:"Optional. Integer 1-2."}|
 
 # advanced_inserter
 |[crafting]{source:"inserter_advanced"}|
-The Advanced Inserter is an upgraded version of the Inserter, which allows filtering, and picking certain items, along with allowing crates and barrels to be picked from minecarts. The Advanced Inserters are much faster, but they require more power
+The Advanced Inserter is an upgraded version of the Inserter, which allows filtering and picking certain items, along with allowing crates and barrels to be picked from minecarts. The Advanced Inserters are much faster, but they require more power.
 
 # advanced_commands
-***Input Variables:***
+**Input Variables:**<br>
 |[data_variable]{type:"string", direction:"in", letter:"c", name:"Command", description:"possible values: add, remove, and clear."}|
 |[data_variable]{type:"string", direction:"in", letter:"a", name:"Action", description:"Possible values: item, block_place, form_minecart, into_minecart."}|
 |[data_variable]{type:"itemstack", direction:"in", letter:"s", name:"Stack", description:"Optional. Itemstack or oreDict String the items have to match"}|
 
 # fluid_inserter
 |[crafting]{source:"inserter_fluid"}|
-The fluid Inserter is a precise limiter of fluid transfer. In some situations, you want to insert only a specific amount of fluid. This device does exactly that
+The Fluid Inserter is a precise limiter of fluid transfer. In some situations, you want to insert only a specific amount of fluid. This device does exactly that.
 
 # fluid_inserter_commands
-
-|[data_variable]{type:"string", direction:"in", letter:"m", name:"Fluid take Mode", description:"possible values: set,
-add"}|
-|[data_variable]{type:"integer", direction:"in", letter:"c", name:"Amount of fluid to take", description:"in Milibuckets"}|
+|[data_variable]{type:"string", direction:"in", letter:"m", name:"Fluid take Mode", description:"possible values: set, add"}|
+|[data_variable]{type:"integer", direction:"in", letter:"c", name:"Amount of fluid", description:"to take, in millibuckets (mB)"}|

--- a/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_logistics/logistics.md
+++ b/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_logistics/logistics.md
@@ -3,5 +3,5 @@ Logistics
 Logi, bmats ASAP!
 
 # intro
-Logistics is a unique branch of engineering focused on storing, delivering and managing the transfer of goods. A good logistic system consists of a warehouse for storage and nearby production for quick manufacturing.
-With the newest electronic technology, and some old rotary powered machines, creating a good delivery system has never been easier.
+Logistics is a unique branch of engineering focused on [storing, delivering and managing] the [transfer of goods.] A good logistic system consists of a warehouse for storage and nearby production for quick manufacturing.
+With the newest electronic technology, and some old [rotary](rotary_power.md) [powered machines](skycrate_system.md), creating a good delivery system has never been easier.

--- a/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_logistics/mechanical_pump.md
+++ b/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_logistics/mechanical_pump.md
@@ -7,4 +7,4 @@ Archimedes Screw
 The Mechanical Pump operates on the simple principle of pressure differentials driven by rotary power to move fluids. Due to the materials used to construct the Mechanical pump, it can only extract water.
 
 # operation
-To operate the pump, A wheel must be connected to the rotary input on the top of the pump, and supplied with rotary power. Like electrical pumps, a redstone signal must be applied to the base of the pump to output fluid.
+To operate the pump, a wheel must be connected to the rotary input on the top of the pump, and supplied with [rotary power](rotary_power.md). Like [electrical pumps](fluidPipes#fluidPipes2), a redstone signal must be applied to the base of the pump to output fluid.

--- a/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_logistics/medical_crate.md
+++ b/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_logistics/medical_crate.md
@@ -1,15 +1,16 @@
 # meta
 Medical Crate
-Right, Archimedes
+Right, Archimedes!
 
 # intro
 |[crafting]{source:"medical"}|
-The Medical Crate is a device used for healing wounded entities. After being placed it has to be filled with basic Regeneration Potions to work.
+The Medical Crate is a device used for healing wounded entities. After being placed, it has to be filled with basic [Potions of Regeneration] to work.
 
 # details_1
-Sneaking and right clicking will open or close the crate: when it's closed - its inventory can be accessed, when it's open - right click to receive the effects. The Medical Crate can also apply an "Iron Will" boost effect, increasing mobility and focus while firing weapons while the move called. To gain it, the second slot has to be filled with Golden Apples.
+Sneaking and right clicking will open or close the crate.
+When it's closed, its inventory can be accessed. When it's open, right click to receive the effects. Fill the second slot of the Medical Crate with Golden Apples to enable an **Iron Will** boost effect. This effect [increases mobility and focus] while firing weapons.
 
 # details_2
-An inserter can be installed on top of the crate. To do it, use the wrench on a closed crate and select the appropriate upgrade. After being installed, the crate requires a MV or LV power wire connected directly to it. The installed syringe inserter will automatically heal and give boost to entities around.
+An inserter can be installed on top of the crate. Use the wrench on a closed crate and select the appropriate upgrade. After installation, the crate requires a MV or LV power wire connected directly to it. The installed syringe inserter will automatically heal and give boosts to surrounding entities.
 
 

--- a/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_logistics/packer.md
+++ b/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_logistics/packer.md
@@ -4,28 +4,28 @@ Even more Pipes and Tunnels!
 
 # intro
 |[multiblock]{mb:"II:Packer"}|
-The Packer is a machine used to batch load items into containers, such as crates or bullet magazines. The packer requires a data signal determine how many items should be packed per operation.
-To form it, use a hammer on the 
+The Packer is a machine used to batch load items into containers, such as crates or bullet magazines. 
+To form it, use a [hammer](introduction#introductionHammer) on the [vertical conveyor].
 
 # details
-By default, the packer offers 54 storage slots for items. They can be inputted through a single conveyor on the machines back.
+By default, the packer offers 54 storage slots for items. They can be inserted through a single conveyor on the rear of the machine.
 To operation the machine, it requires electricity and a container to be provided on the 3 block long conveyor.
-For the packing orders, the machine uses a [Task System](task_system.md). Tasks can be added, removed and tweaked through its interface, or the data system.
+For the packing orders, the machine uses a [Task System](task_system.md). Tasks can be added, removed and tweaked through its interface, or the [data system](data_main.md).
 
 # details_2
-The "Pack" task is used to load items into the provided container. By default, the packer can take any item (the * symbol) and the maximum possible amount of it. This can be changed by selecting a different mode. You can choose between taking in a select number of invintory slots, or number of items. The amount can be specified in the interface, in the input field below.
+The ["Pack"] task is used to load items into the provided container. By default, the packer can take any item (the * symbol) and the maximum possible amount of it. This can be changed by selecting a different mode. You can choose between taking in a select number of invintory slots, or number of items. The amount can be specified in the interface, in the input field below.
 
 # details_3
-The "Use OreDict" switch determines whether items with the same Ore Dictionary key will be matched. The "NBT Sensitive" switch determines weather the item has to have the same NBT tag as the one provided. This is disabled by default  
+The ["Use OreDict"] switch determines whether items with the same Ore Dictionary key will be matched. The ["NBT Sensitive"] switch determines weather the item has to have the same NBT tag as the one provided. This is disabled by default.
 
 # details_4
-The "Unpack", "Fill", "Unfill", "Charge" and "Discharge" tasks work in a similar way as the "Pack" task. For fluids, "Slots" are tanks and the amount is the fluid amount in mB. For energy, only the amount is taken into consideration.
+The ["Unpack"], ["Fill"], ["Unfill"], ["Charge"] and ["Discharge"] tasks work in a similar way as the ["Pack"] task. For fluids, ["Slots"] are tanks and the amount is the fluid amount in mB. For energy, only the amount is taken into consideration.
 
 # data_1
 |[data_variable]{type:"string", direction:"in", letter:"c", name:"Command", description:"Possible values: add, remove, clear."}|
-|[data_variable]{type:"integer", direction:"in", letter:"a", name:"Action", description:"Possible Values: Item, Fluid, energy."}|
-|[data_variable]{type:"integer", direction:"in", letter:"s", name:"Stack", description:"Optional. the ItemStack or OreDict String the items have to match."}|
+|[data_variable]{type:"string", direction:"in", letter:"a", name:"Action", description:"Possible Values: item, fluid, energy."}|
+|[data_variable]{type:"itemstack", direction:"in", letter:"s", name:"Stack", description:"Optional. the ItemStack or OreDict String the items have to match."}|
 
 # data_2
-|[data_variable]{type:"boolean", direction:"in", letter:"m", name:"Mode", description:"Possible values: amount, slot, all_possible. Optional, by default all_possible."}|
-|[data_variable]{type:"boolean", direction:"in", letter:"e", name:"Expire After", description:"Optional. After how many cycles should the task end."}|
+|[data_variable]{type:"string", direction:"in", letter:"m", name:"Mode", description:"Possible values: amount, slot, all_possible. Optional, by default all_possible."}|
+|[data_variable]{type:"integer", direction:"in", letter:"e", name:"Expire After", description:"Optional. After how many cycles should the task end."}|

--- a/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_logistics/repair_crate.md
+++ b/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_logistics/repair_crate.md
@@ -1,13 +1,15 @@
 # meta
 Repair Crate
-Approved by the Ministry of Nuts and Bolts
+Nuts and Bolts!
 
 # intro
 |[crafting]{source:"repair"}|
-The Repair Crate is a device used for repairing equipped items and if upgraded - nearby vehicles. After being placed it has to be supplied with steel plates to work.
+The Repair Crate is a device used for repairing equipped items and if upgraded - nearby vehicles. After being placed, it must be supplied with steel plates to work.
 
 # details_1
-Sneaking and right clicking will open or close the crate: when it's closed - its inventory can be accessed, when it's open - right click to receive the effects. The Repair Crate will repair all items held and worn by the user.
+Sneaking and right clicking will open or close the crate.
+When it's closed, its inventory can be accessed. When it's open, right click to receive the effects.
+The Repair Crate will repair all items held and worn by the user.
 
 # details_2
-An inserter can be installed on top of the crate. To do it, use the wrench on a closed crate and select the appropriate upgrade. After being installed, the crate requires a MV or LV power wire connected directly to it. The installed welder inserter will automatically repair equipped items, vehicles and blocks around.
+An inserter can be installed on top of the crate. Use the wrench on a closed crate and select the appropriate upgrade. After installation, the crate requires a MV or LV power wire connected directly to it. The installed welder inserter will automatically repair equipped items and surrounding vehicles and blocks.

--- a/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_logistics/rotary_power.md
+++ b/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_logistics/rotary_power.md
@@ -3,30 +3,42 @@ Rotary Power
 Things Start Turning
 
 # torque and speed
-Rotary power is an old-fashioned alternative to electric power. Instead of wires and connectors, wheels and motor belts are used. The power system utilizes 2 factors: torque - in TU (Torque Unit) and speed in DPT (Degrees per Tick). Machines require different torque and speed to work effectively. Devices like the [Sawmill](Sawmill.md) and the [Mechanical Pump](mechanicalpump.md) uses mechanical power.
+Rotary power is an old-fashioned alternative to electric power. Instead of wires and connectors, [wheels] and [motor belts] are used. The power system utilizes 2 factors: torque - in [TU] (Torque Unit) and speed in [DPT] (Degrees per Tick). Different machines require different torque and speed to work effectively.
+Devices like the [Sawmill](Sawmill.md) and the [Mechanical Pump](mechanical_pump.md) use mechanical power.
 
 # torque and speed 2
-If any of those values surpasses the limit, the machine explodes. Power can be merged and split using [Gearboxes](rotary_power.md#gearboxes),
+If [TU] or [DPT] values surpass the limit of the machine, the machine **explodes**. To prevent this, the cunning Engineer may use [Gearboxes](rotary_power.md#gearboxes) to merge, split, and manage rotary devices.
 
 # transmissions
 |[crafting]{source:"transmission"}|
-The Transmission Boxes are used to connect mechanical devices using a different standard of axles, they can be used to connect a windmill or a waterwheel to a motor belt network or output mechanical energy to a dynamo.
+[Transmission Boxes] are used to connect to mechanical devices generating rotational energy. They can be used to connect a [windmill](generator#generator2) or a [waterwheel](generator#generator1) to a [motor belt] network or output mechanical energy to a dynamo.
 
 # gearboxes
 |[crafting]{source:"gearbox"}|
-The Gearboxes are used to link multiple wheels together, their sides can be changed to input, output or nothing. Input torque from all inputs is summed and then divided equally between all outputs. You can use the gearbox to merge torque to make it higher or divide it between 2 or more wheels.
+[Gearboxes] are used to link multiple [wheels] together. Their sides can be changed to input, output or nothing. Input torque from all inputs is summed and then divided equally between all outputs. You can use the gearbox to merge torque to make it higher or divide it between two or more wheels.
 
 # wheels
 |[crafting]{source:"wheels"}|
-The wheel is used to transfer mechanical (rotary) power between devices. After placing, it can be connected to another wheel using a motor belt, the same way connectors are linked with wires.
+The [wheel] is used to transfer mechanical (rotary) power between devices. After placing, it can be connected to another wheel using a [motor belt], the same way [connectors](wiring) are linked with wires.
 
 # belts
 |[crafting]{source:"belt"}|
-The motor belts are the main transmission element of every rotary power network. They differ with the amount of torque and speed they can transfer. If the torque is too high for the belt, it will detach from the wheel and fall onto the ground. Use different materials for different needs.
+The [motor belts] are the main transmission element of every rotary power network. They differ with the amount of torque and speed they can transfer. If the torque is too high for the belt, it will detach and fall onto the ground.
+
+# belt_materials1
+|[item_display]{source:"belt_cloth"}|
+<br>**Cloth belts** are fabricated from tough fabric and leather. They have the lowest torque tolerance and shortest length, but are [cheap] and fairly efficient at transferring torque.
+# belt_materials2
+|[item_display]{source:"belt_steel"}|
+<br>**Steel tracks** are fabricated from steel plates. They have the [highest torque tolerance] and can be twice the length of cloth belts, but lose a lot of torque compared to other types.
+#belt_materials3
+|[item_display]{source:"belt_rubber"}|
+<br>**Rubber belts** are fabricated from [vulcanized](vulcanizer.md) rubber. They have a fair torque tolerance and can be twice the length of cloth belts, and are the most efficient at transferring torque. However, the [industrial requirements](vulcanizer.md) for fabrication are much more than other types.
 
 # gears
 |[item_display]{source:"gears"}|
 Gears can be used to change the ratio for Torque and Speed for [Gearboxes](rotary_power.md#gearboxes).
+The Torque/Speed ratio is engraved on the gear at production for the busy Engineer to refer to at any time.
 
 
 

--- a/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_logistics/sawmill.md
+++ b/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_logistics/sawmill.md
@@ -4,11 +4,11 @@ The better fidget spinner!
 
 # intro
 |[multiblock]{mb:"II:Sawmill"}|
-The Sawmill is an automatic carpentry machine powered by [rotary](rotary_power.md) energy. It consists of a table, a mechanical inserter and saw mount. To form the multiblock, use a hammer on the middle wooden scaffolding.
+The Sawmill is an automatic carpentry machine powered by [rotary](rotary_power.md) energy. It consists of a table, a mechanical inserter and saw mount. To form the multiblock, use a [hammer](introduction#introductionHammer) on the middle wooden scaffolding.
 
 # saw_blades
-|[recipe]{source:"blades"}|
-Saws made of different materials can be mounted. While every saw is effective at cutting wood, saws made of hard materials like steel and tungsten can even cut through metals.
+|[crafting]{source:"blades"}|
+Saws made of different materials can be mounted. While every saw is effective at cutting wood, saws made of hard materials like [steel] and [tungsten] can even cut through metals.
 
 # slots
-The machine requires a constant supply of rotary power to it's side. Resources can be inserted to table's right side and processed items are outputted to the wooden storage box on the ground
+The machine requires a constant supply of rotary power to it's side. Resources can be inserted to table's right side and processed items are outputted to the wooden storage box on the ground.

--- a/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_logistics/skycrate_system.md
+++ b/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_logistics/skycrate_system.md
@@ -5,29 +5,35 @@ Same Day Delivery
 # intro
 The Skycrate system is a different approach on delivering items. Its speed surpasses any conveyor, and the usage of rope makes it cheaper and more space-efficient. There are also drawbacks however; it requires stations on both sides and a number of posts depending on the length of the system. Skycrates are a better option than conveyors on longer distances, and is not encouraged to use them for short (0-30m) distances.
 
+# warning
+**Letter of notice from the Engineering Department:**<br>
+The Engineering Department has spent countless hours and funds attempting to implement advanced techniques into the aging Skycrate system, but tragically, have not been fruitful.
+<br>All Engineers wishing to develop a Skycrate system shall ensure that **all chunks between start and end stations are loaded**.
+
+# warning2
+The Engineering Department is not responsible for loss of goods along unloaded ziplines. Sign below to confirm you have [read and understood this warning.]<br>
+X
+------------------------------
+
 # skycrate
 |[multiblock]{mb:"II:SkycrateStation"}|
-The Skycrate station is both the starting and stopping point of the delivery system. To form it, use a hammer on the scaffolding in the middle.
-To function, it requires rotary power to be inputted to its side
+The Skycrate station is both the starting and stopping point of the delivery system. To form it, use a [hammer](introduction#introductionHammer) on the scaffolding in the middle.
+To function, it requires rotary power to be inputted to its side.
 
 # details_crate
-The amount of gears increase its efficiency, similar how it works with [Gearboxes](rotary_power.md#gearboxes)
-The station uses mounts to put crates into the delivery system. The mounts are taken from the back, behind the inserter. The crates are inserted and outputted on the conveyor. A crate can be forced out of the station by applying a redstone signal.
+The amount of gears increase its efficiency, similar how it works with [Gearboxes](rotary_power.md#gearboxes).
+The station uses [mounts](#frames) to put crates into the delivery system. The mounts are taken from a [user-supplied crate] placed behind the inserter on the rear of the machine. Transport crates are inserted and outputted on the conveyor. A crate can be forced out of the station by applying a redstone signal.
 
 # skycart
-|[multiblock]{mb:"II:SkycrateStation"}|
-The Skycart station is both the starting and stopping point of the delivery system. To form it, use a hammer on the scaffolding in the middle.
-To function, it requires rotary power to be inputted to its side
-
+|[multiblock]{mb:"II:SkycartStation"}|
+The Sky*cart* station is similar to the Sky*crate* station, using minecarts and rails instead of crates and conveyors. To form it, use a [hammer](introduction#introductionHammer) on the scaffolding in the middle.
 
 # details_cart
-Like its Skycrate counterpart, the station uses mounts to put the contents of the carts into the delivery system. minecrafts can only enter the station when the railway barrier is up. A minecraft can be forced out of the station by applying a redstone signal. The station will automatically expel minecarts after a loading/unloading operation.
-
+Like its Skycrate counterpart, the station uses [mounts](#frames) to put the contents of the carts into the delivery system. Minecarts can only enter the station when the railway barrier is up. A minecart can be forced out of the station by applying a redstone signal. The station will automatically expel minecarts after a loading/unloading operation.
 
 # skycrate_post
 |[multiblock]{mb:"II:SkycratePost"}|
-The Skycrate Post is the relay between two points in the skycrate network. Only two wires can be attached to the pylon at the same time. To form it, use a hammer on the fence
-
+The Skycrate Post is the relay between two points in the skycrate network. Only two wires can be attached to the pylon at the same time. To form it, use a [hammer](introduction#introductionHammer) on the fence.
 
 # minecarts
 |[item_display]{source:"minecart_general"}|
@@ -35,4 +41,4 @@ Crate carts are a safe way to transport items via rail. They can be crafted by p
 
 # frames
 |[crafting]{source:"mount"}|
-The Skycrate mounts are used to transport crates via the zipline. There are two models: The basic ones and the electric ones, which use energy provided on the way via nearby **Tesla Coils**. 
+The Skycrate mounts are used to transport crates via the zipline. There are two models: The basic ones and the electric ones, which use energy provided on the way via nearby [Tesla Coils](teslaCoil). 

--- a/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_logistics/task_system.md
+++ b/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_logistics/task_system.md
@@ -3,9 +3,9 @@ Task System
 Keep it Simple, Stupid
 
 # intro
-The task system is a concept of organising a machine's work schedule through a single iterable task. Tasks are used by many data devices, such as the inserters, packers and the data routers. Tasks are divided into two groups:
-Jobs - tasks which will execute infinitely, unless manually removed.
-Requests - tasks which are temporary, and will remove themselves after they are finished (i.e. after an inserter picks up a certain amount of items)
+The task system is a concept of organising a machine's work schedule through a single iterable task. Tasks are used by many data devices, such as the [inserters](inserters.md), [packers](packer.md) and the [data routers](small_data_devices.md#router). Tasks are divided into two groups:
+**Jobs** - tasks which will execute infinitely, unless manually removed.
+**Requests** - tasks which are temporary, and will remove themselves after they are finished (i.e. after an inserter picks up a certain amount of items)
 
 # details
-By default, tasks are executed from the oldest fo the newest. If a task cannot be executed, it will be skipped. After finishing a Request (successfully or not), it is checked whether it should be removed.
+By default, tasks are executed from the oldest to the newest. If a task cannot be executed, it will be skipped. After finishing a [Request] __(successfully or **not**)__, it is checked whether it should be removed.


### PR DESCRIPTION
Complete sweep through Logistics category of II Manual. Upgrades, fixes, and adds significant information and content to all pages within the section.
1. Extensive formatting added to pages to highlight important info, make links, and convey ideas.
2. Fix variable types for Packer
3. Fix details of variables for Inserters (direction int can be 0-3, not 0-2)
4. Letter of Notice added to Skycrate station section detailing chunk loading requirements. Fixed incorrect model for skycart station display.
5. Info on upgrades added to Fence section. Unique flavour text for each variant added.
6. Added in-depth info pages on belts in Rotary Power section.
7. Medical and repair crates received a grammar and writing clean up
8. Added some game mechanic info to capacitor backpack
9. Fixed blade crafting display on Sawmill