### PR TITLE
Update Intel & Motorworks categories, and reinstate Other category

### DIFF
--- a/src/main/java/pl/pabilo8/immersiveintelligence/client/ClientProxy.java
+++ b/src/main/java/pl/pabilo8/immersiveintelligence/client/ClientProxy.java
@@ -750,6 +750,6 @@ public class ClientProxy extends CommonProxy
 		IIManualCategoryWarfare.INSTANCE.addPages();
 		IIManualCategoryMotorworks.INSTANCE.addPages();
 		IIManualCategoryIntelligence.INSTANCE.addPages();
-		//IIManualCategoryOther.INSTANCE.addPages();
+		IIManualCategoryOther.INSTANCE.addPages();
 	}
 }

--- a/src/main/java/pl/pabilo8/immersiveintelligence/client/manual/categories/IIManualCategoryIntelligence.java
+++ b/src/main/java/pl/pabilo8/immersiveintelligence/client/manual/categories/IIManualCategoryIntelligence.java
@@ -29,13 +29,14 @@ public class IIManualCategoryIntelligence extends IIManualCategory
 				.addSource("alarm_siren", getSourceForItem(IIContent.blockDataConnector.getStack(IIBlockTypes_Connector.ALARM_SIREN)));
 
 		addEntry("radar");
+		addEntry("binoculars")
+				.addSource("binoculars", getSourceForItem(new ItemStack(IIContent.itemBinoculars)))
+				.addSource("infbinoculars", getSourceForItem(new ItemStack(IIContent.itemBinoculars, 1, 1)));
+		
 		addEntry("tripod_periscope")
 				.addSource("tripod_periscope", getSourceForItem(
 						new ItemStack(IIContent.itemTripodPeriscope)));
-
-		addEntry("binoculars")
-				.addSource("binoculars", getSourceForItem(
-					new ItemStack(IIContent.itemBinoculars)));
-
+						
+		addEntry("strategic_command_table");
 	}
 }

--- a/src/main/java/pl/pabilo8/immersiveintelligence/client/manual/categories/IIManualCategoryMotorworks.java
+++ b/src/main/java/pl/pabilo8/immersiveintelligence/client/manual/categories/IIManualCategoryMotorworks.java
@@ -32,14 +32,13 @@ public class IIManualCategoryMotorworks extends IIManualCategory
 	public void addPages()
 	{
 		super .addPages();
-		addEntry("coagulator");
-		addEntry("fuel_station");
 		addEntry("motorworks");
-		addEntry("rubber_production");
+		addEntry("fuel_station");
 		addEntry("vehicle_workshop");
+		addEntry("rubber_production");
+		addEntry("coagulator");
 		addEntry("vulcanizer")
-
-				//.addSource("compound_silicon", getSourceForItem(new ItemStack(IIitemMaterial)))
+				.addSource("compound", getSourceForItem(new ItemStack(IIContent.itemMaterial, 1, 31)))
 				.addSource("vulcanizer_blueprint", getSourceForItem(
 						BlueprintCraftingRecipe.getTypedBlueprint("vulcanizer_molds")
 				));

--- a/src/main/java/pl/pabilo8/immersiveintelligence/client/manual/categories/IIManualCategoryOther.java
+++ b/src/main/java/pl/pabilo8/immersiveintelligence/client/manual/categories/IIManualCategoryOther.java
@@ -1,5 +1,45 @@
 package pl.pabilo8.immersiveintelligence.client.manual.categories;
 
-public class IIManualCategoryOther
+import blusunrize.immersiveengineering.api.ManualHelper;
+import blusunrize.immersiveengineering.api.ManualPageBlueprint;
+import blusunrize.immersiveengineering.api.ManualPageMultiblock;
+import blusunrize.immersiveengineering.api.crafting.BlueprintCraftingRecipe;
+import blusunrize.lib.manual.ManualPages;
+import net.minecraft.item.ItemStack;
+import pl.pabilo8.immersiveintelligence.client.manual.IIManualCategory;
+import pl.pabilo8.immersiveintelligence.common.IIContent;
+import pl.pabilo8.immersiveintelligence.common.util.IIReference;
+
+/**
+ * @author Pabilo8 and fastdelaspeed
+ * @since 20-02-2025
+ */
+public class IIManualCategoryOther extends IIManualCategory
 {
+	public static IIManualCategoryOther INSTANCE = new IIManualCategoryOther();
+
+	@Override
+	public String getCategory()
+	{
+		return IIReference.CAT_OTHER;
+	}
+
+	@Override
+	public void addPages()
+	{
+		super .addPages();
+		addEntry("electric_tools")
+				.addSource("e_hammer", getSourceForItem(new ItemStack(IIContent.itemHammer)))
+				.addSource("e_wrench", getSourceForItem(new ItemStack(IIContent.itemElectricWrench)))
+				.addSource("e_cutter", getSourceForItem(new ItemStack(IIContent.itemWirecutter)
+		));
+		
+		addEntry("lighter")
+				.addSource("lighter", getSourceForItem(new ItemStack(IIContent.itemLighter)
+		));
+		
+		addEntry("measuring_cup")
+				.addSource("m_cup", getSourceForItem(new ItemStack(IIContent.itemMeasuringCup)
+		));
+	}
 }

--- a/src/main/java/pl/pabilo8/immersiveintelligence/common/util/IIReference.java
+++ b/src/main/java/pl/pabilo8/immersiveintelligence/common/util/IIReference.java
@@ -117,6 +117,7 @@ public class IIReference
 	public static final String CAT_LOGISTICS = "ii_logistics";
 	public static final String CAT_INTELLIGENCE = "ii_intel";
 	public static final String CAT_MOTORWORKS = "ii_motorworks";
+	public static final String CAT_OTHER = "ii_other";
 
 	//--- GUI ---//
 

--- a/src/main/java/pl/pabilo8/immersiveintelligence/common/util/IISkinHandler.java
+++ b/src/main/java/pl/pabilo8/immersiveintelligence/common/util/IISkinHandler.java
@@ -246,17 +246,17 @@ public class IISkinHandler
 
 	public static void getManualPages()
 	{
-		ManualHelper.getManual().manualContents.removeAll("contributor_skins");
+		ManualHelper.getManual().manualContents.removeAll("Contributor Skins");
 		ArrayList<ManualPages> skin_pages = new ArrayList<>();
-		skin_pages.add(new ManualPages.Text(ManualHelper.getManual(), "contributor_skins"));
+		skin_pages.add(new ManualPages.Text(ManualHelper.getManual(), "Contributors of Immersive Intelligence, whether through direct help by providing assets, code, translations, recording tutorial videos, donations through Patreon or simply contributing to II community, can not be overlooked and have to be rewarded.\nFor that, a collection of skins has been added to the game, these are applicable to various weapons, ranging from machineguns to howitzers. Huge thanks to all of you, without you this project would take much longer than Soon(TM)."));
 		for(IISpecialSkin skin : IISkinHandler.specialSkins.values())
 			skin_pages.add(new IIManualPageContributorSkin(ManualHelper.getManual(), skin));
 
-		ManualEntry contributor_skins = ManualHelper.getManual().getEntry("contributor_skins");
+		ManualEntry contributor_skins = ManualHelper.getManual().getEntry("Contributor Skins");
 		if(contributor_skins==null)
 		{
-			contributor_skins = new ManualEntry("contributor_skins", IIReference.CAT_WARFARE);
-			ManualHelper.getManual().manualContents.put(IIReference.CAT_WARFARE, contributor_skins);
+			contributor_skins = new ManualEntry("Contributor Skins", IIReference.CAT_OTHER);
+			ManualHelper.getManual().manualContents.put(IIReference.CAT_OTHER, contributor_skins);
 		}
 
 		contributor_skins.setPages(skin_pages.toArray(new ManualPages[]{}));

--- a/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_intel/alarm_siren.md
+++ b/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_intel/alarm_siren.md
@@ -1,8 +1,8 @@
 # meta
 Alarm Siren
-The reactor is OK, was, at least.
+The reactor is OK!... was, at least.
 
 # alarm siren 1
 |[crafting]{source:"alarm_siren"}|
-The alarm siren is a device, which emits a loud noise when provided a redstone signal (volume depends on signal strength).
-Redstone wire can be attached from any side. The siren, like every redstone connector, can be reconfigured to use a different redstone channel (default is white).
+The alarm siren is a device which emits a loud noise when provided a redstone signal. Volume depends on signal strength.
+[Redstone wire](redstoneWire) can be attached from any side. The siren, like every redstone connector, can be reconfigured to use a different redstone channel.

--- a/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_intel/binoculars.md
+++ b/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_intel/binoculars.md
@@ -2,30 +2,26 @@
 Binoculars
 The Ballerina Onlooker
 
-# 0
-Information is best gather when the observed target don't notice your activity, for when a target don't know that they are observed they will act natural.
+# intro
+Information is best gathered when the observed target is unaware of your presence. The target will act natural, and allow you an insight into their patterns and tendencies.
+This can be done in a variety of ways, through infiltration and espionage... but the safest option of them all is observation from afar.
 
-This can be done in a variety of ways, one being infiltration and espionage on a more personal level.
-But the safest option of them all is observation from afar.
-
-# 1
+# crafting
 |[crafting]{source:"binoculars"}|
-Utilizing the optical phenomenon of refraction and lenses observation from a far can be done by ease.
-By using the same method as the precision scope and a metal binding, a **Binoculars** can be constructed.
+Utilizing the optical phenomenon of refraction and lenses, observation from a far can be done by ease.
+By carefully crafting glass into prisms and lenses and inserting them into a metal frame, a pair of **Binoculars** can be constructed.
 
-# 2
-The **Binoculars** are used by *sneaking*, and with the new research in optical mechanics and multiple lenses the ability to zoom on command makes for a great recon device.
+# usage
+The **Binoculars** are used by holding the item in your hand and [sneaking]. With the new research in optical mechanics and multiple lenses the ability to zoom on command makes for a great recon device.
+A small gyroscope has been installed to indicate your yaw in degrees, for your peripheral vision is blocked by the **Binoculars**.
 
-When you are extending you vision the orientation can be hard to keep track on, for your peripheral vision is blocked by
-the **Binoculars**.
-To not get disorientated when using the device a small gyroscope has been installed to indicate your yaw in degrees.
+# infra
+|[crafting]{source:"infbinoculars"}|
+The **Infrared Binoculars** are a more advanced version of the tried and true **Binoculars**. They have cutting edge optical technology and electronics to make it possible to see with minimal reflections of light.<br>
 
-# 3
-|[crafting]{source:"crafting_infbinoculars"}|
-The **Infrared Binoculars** is a more advanced version of the accustomed **Binoculars**. They have cutting edge technology in
-optics and electronics to make it possible to see with minimal reflections of light. The **Infrared Binoculars** excels at intelligence gathering in the dark vail of the night.
+# infra1
+With the **Infrared Binoculars**, the stealthy Engineer will excel at intelligence gathering in the dark veil of the night.
+<br>However, with new technology comes new responsibility. Due to the low-light design allowing in large quantities of light, the **Infrared Binoculars** should [not be used] in [bright areas]. Doing so may lead to **temporary blindness.**
 
-# 4
-But with new technology comes new responsibility. Because the way the lenses let in big quantity of light the **Infrared Binoculars** should be **cautioned against** to turn on in *broad daylight*.
-
-The **Infrared Binoculars** runs on power and if no power is supplied the night vision cant be toggled on. If combined with the capacitor backpack the device can be charged on the move.
+# infra2
+The **Infrared Binoculars** require energy to operate. If no power is supplied, the infrared vision cannot be toggled on. If the user wears a [capacitor backpack](powerpack), the device can be charged on the move.

--- a/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_intel/intel_main.md
+++ b/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_intel/intel_main.md
@@ -1,10 +1,10 @@
 # meta
 Intelligence
-Knowledge is power
+Knowledge is Power
 
-# 0
-The collection of information of military or political value has always been a focus of the technological advancements, 
-information is beautiful. Intelligence is not only the gather of information, but also the way to use it.
-
-Surveillance, reconnaissance, and sabotage all is under the intelligence umbrella. As well as corporate espionage. 
-Intelligence is the lifeblood of the new warfare tactics and strategy.
+# intro
+Information is beautiful.<br>
+The collection of information of military or political value has always been a focus of the technological advancements.
+However, intelligence is not only the gather of information, but also the way to use it.
+Surveillance, reconnaissance, espionage, and sabotage are all under the intelligence umbrella.
+<br>Intelligence is the lifeblood of new warfare tactics and strategy.

--- a/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_intel/radar.md
+++ b/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_intel/radar.md
@@ -5,9 +5,9 @@ A relic of Dover
 # multiblock and description
 @level_circuits,hammer_electric,upgradable
 |[multiblock]{mb:"II:Radar"}|
-Radar is the large detection device, capable of detecting entities in a direct line over incredibly long distances, including (and especially) all metal objects and artillery shells. 
-To form it use a hammer on the left wooden scaffolding block.
+The [Radar] is a large detection device, capable of detecting entities in a direct line over incredibly long distances.
+To form it, use a [Hammer](introduction#introductionHammer) on the left wooden scaffolding block.
 
 # radar 2
-Radar has multiple uses. It can be linked with emplacement weapons, such as the CPDS and used to intercept projectiles at long ranges. It can also be linked with the Strategic Command Table [WIP].
-If upgraded with Triangulators, the radar can also detect radio signals within its range and determine their location, this allows ambushing unsuspecting enemies with precise artillery strikes. In order to operate the Radar requires a constant supply of electricity.
+Radar has multiple uses. It can be linked to emplacement weapons, such as the [CPDS](emplacement_weapons.md#cpds0), and used to intercept projectiles at long ranges. It can also be linked with the [Strategic Command Table](strategic_command_table.md) [(WIP)].
+If upgraded with [Triangulators], the radar can also detect [radio signals](radio_station.md) within its range and determine their location. This allows ambushing unsuspecting enemies with precise artillery strikes. In order to operate, the Radar requires a constant supply of electricity.

--- a/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_intel/radar.md
+++ b/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_intel/radar.md
@@ -6,7 +6,7 @@ A relic of Dover
 @level_circuits,hammer_electric,upgradable
 |[multiblock]{mb:"II:Radar"}|
 The [Radar] is a large detection device, capable of detecting entities in a direct line over incredibly long distances.
-To form it, use a [Hammer](introduction#introductionHammer) on the left wooden scaffolding block.
+To form it, use a [Electric Hammer](electric_tools.md) on the left wooden scaffolding block.
 
 # radar 2
 Radar has multiple uses. It can be linked to emplacement weapons, such as the [CPDS](emplacement_weapons.md#cpds0), and used to intercept projectiles at long ranges. It can also be linked with the [Strategic Command Table](strategic_command_table.md) [(WIP)].

--- a/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_intel/strategic_command_table.md
+++ b/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_intel/strategic_command_table.md
@@ -1,6 +1,7 @@
 # meta
-Strategic Command Table
+Strategic Command Table (WIP)
 Art of War
 
-# 0
+# intro
+This item is a work in progress! The Engineering Department is working hard to bring it to the front!
 

--- a/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_intel/tripod_periscope.md
+++ b/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_intel/tripod_periscope.md
@@ -4,10 +4,10 @@ Spectacles on Sticks
 
 # craft and intro
 |[crafting]{source:"tripod_periscope"}|
-Tripod periscope is an observation device consisting of a pair of binoculars, magnifying tubes, a rotation mechanism and a tripod.
+Tripod periscope is an observation device consisting of a pair of binoculars, magnifying tubes, a rotation mechanism, and a tripod.
 The Tripod Periscope allows peeking out of a trench, or a wall without the risk of getting shot.
 
 # tripod periscope 2
-Compared to the standard Binoculars, Tripod Periscope has superior zoom capabilities, allowing one to scout further and see objects at extremely far distances.
-<br>Deployment of the Tripod is similar to that of a Machinegun, requiring you to place the item down on the ground and then interact with it while having an empty hand. 
-To pick it up, sneak and interact with it.
+Compared to the standard [Binoculars](binoculars.md), the Tripod Periscope has superior zoom capabilities, allowing one to scout further and see objects at extremely far distances.
+<br>Deployment of the Tripod is similar to that of a [Machinegun](machinegun.md), requiring you to [place the item down on the ground] and then [interact with it while having an empty hand.] 
+<br>To pick it up, [sneak] and interact with it.

--- a/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_motorworks/coagulator.md
+++ b/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_motorworks/coagulator.md
@@ -4,10 +4,11 @@ Intensified Mixing Co.
 
 # intro
 |[multiblock]{mb:"II:Coagulator"}|
-The coagulator is a machine used to coagulate latex and form raw rubber balls for further processing. To form it use a hammer on the middle sheetmetal block on machine's back.
+The coagulator is a machine used to coagulate [latex] and form raw [rubber balls] for [further processing](vulcanizer.md). To form it, use a [Hammer](introduction#introductionHammer) on the middle sheetmetal block on machine's rear.
 
 # coagulator usage
-The coagulator requires a supply of electricity to its heavy connector port and a steady supply of latex (right tank) and formic acid (left tank), take note that the sides swap if the machine is flipped.
+The [coagulator] requires a supply of electricity to its heavy connector port and a steady supply of [latex] (right tank) and [formic acid] (left tank). Take note that the sides swap if the machine is flipped.
 
 # coagulator usage 2
-After latex is mixed with the acid and the upper "quark" layer forms, the crane will pick one of the buckets, submerge it and put it back while a timer is automatically set. After some time, the latex will solidify into raw rubber, which will be outputted by a mechanism holding the bucket. The rubber will be dropped onto the ground.
+After [latex] is mixed with the acid and the upper "quark" layer forms, the crane will pick one of the buckets, submerge it and put it back while a timer is automatically set. After some time, the [latex] will solidify into [raw rubber], which will be outputted by a mechanism holding the bucket. The rubber will be dropped onto the ground.
+It is recommended to place [conveyor belts](conveyor) to collect the latext.

--- a/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_motorworks/fuel_station.md
+++ b/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_motorworks/fuel_station.md
@@ -4,9 +4,8 @@ Does NOT sell hot-dogs
 
 # intro
 |[multiblock]{mb:"II:FuelStation"}|
-The Fuel Station is a device used for automatic refuel of vehicles nearby. To form it use a hammer on the left light engineering block.
+The Fuel Station is a device used for automatic refuel of [vehicles] nearby. To form it use a [Hammer](introduction#introductionHammer) on the left light engineering block.
 
 # useage
-The Fuel Station requires a supply of power to operate. The fuel needed depends on the vehicle, many vehicles, like motorbikes use **diesel**, but motorboats use **gasoline**.
-
-
+The Fuel Station requires a supply of power to operate. The Fuel Station will refuel any vehicle that is nearby. The fuel needed depends on the vehicle.
+<br>Many vehicles, like [motorbikes] use **diesel**, but [motorboats] use **gasoline**.

--- a/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_motorworks/motorworks.md
+++ b/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_motorworks/motorworks.md
@@ -3,5 +3,4 @@ Motorworks
 Full throttle!
 
 # intro
-Motorworks is a branch of engineering focused on construction of vehicles and enhancing the performance of other tasks. Vehicles increase speed of transportation of personnel and goods, and by that improve the overall efficiency of your factory. Vehicles can also be utilised to gain advantage in combat.
-
+Motorworks is a branch of engineering focused on construction of [vehicles] and enhancing the performance of other tasks. Vehicles increase speed of transportation of personnel and goods, and by that improve the overall efficiency of your factory. Vehicles can also be utilised to [gain advantage in combat.]

--- a/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_motorworks/rubber_production.md
+++ b/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_motorworks/rubber_production.md
@@ -3,18 +3,20 @@ Rubber Production
 Happy Little Trees
 
 # rubber_trees
-he first step in rubber production is finding and gathering saplings of the **Rubber Trees** found in the jungle biome. These trees are a valuable source of latex - a white fluid, which is the main component of industrial rubber. 
-The second step is creating a rubber plantation, when the tree saplings are grown, carve the extraction hole log using an axe.
+The first step in rubber production is finding and gathering saplings of the **Rubber Trees** found in the jungle biome. These trees are a valuable source of [latex] - a white fluid which is the main component of industrial rubber. 
+The second step is creating a rubber plantation, when the [tree saplings] are grown, carve the [extraction hole log] using an [axe].
 
 # rubber_trees_2
-Then place a latex collector next to the tree and use a bucket on a collector to make it gather latex.
-If more than one collector is next to the tree, the latex will be split between all of them. When the bucket is full, interact with the collector to regain it.
+Then, place a [latex collector] next to the tree and use a bucket on a collector to make it gather latex.
+If more than one collector is next to the tree, the latex will be split between all of them. When the bucket is full, interact with the collector to pick it up.
 
 # chemical_steps
-To start coagulating latex into raw rubber two things are needed: **formic acid** and [Coagulator](coagulator.md). To produce formic acid a [Refinery](refinery.md) is required. Combine Carbon Monoxide with Methanol to create Formic Acid.
-Carbon monoxide can be produced through electrolysis of carbon dioxide, a pollutant and byproduct collected by the **Carbon Dioxide Filter**
-Methanol can be produced by mixing nickel or platinum with hydrogen, created through electrolysis of water. The last step is to combine both using the [Refinery](refinery.md).
+To start coagulating latex into raw rubber, two things are needed: **formic acid** and a [Coagulator](coagulator.md).
+To produce formic acid, a [Refinery](refinery.md) is required. Combine [carbon monoxide] with [methanol] to create Formic Acid.
 
+# chemical_steps1
+Carbon monoxide can be produced through [electrolysis](electrolyzer.md) of carbon dioxide, a pollutant and byproduct collected by the [Carbon Dioxide Filter](carbon_filter.md).
+Methanol can be produced by mixing nickel or platinum with hydrogen, created through [electrolysis](electrolyzer.md) of water. The last step is to combine both using the [Refinery](refinery.md).
 
 # processing
-When latex and formic acid are acquired, it's time for some coagulation. Use the machine to create **raw rubber balls** and then press them into sheets using a plate mold in the [Metal Press](metalpress.md). The last step is vulcanization of raw rubber sheets. Use the [Vulcanizer](vulcanizer.md) to produce rubber tires or belts.
+When latex and formic acid are acquired, it's time for some coagulation. Use the [Coagulator](coagulator.md) to create **raw rubber balls** and then press them into sheets using a plate mold in the [Metal Press](metalPress). The last step is vulcanization of raw rubber sheets. Use the [Vulcanizer](vulcanizer.md) to produce rubber tires or belts.

--- a/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_motorworks/vehicle_workshop.md
+++ b/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_motorworks/vehicle_workshop.md
@@ -4,14 +4,14 @@ Beginning of the Joyride
 
 # intro
 |[multiblock]{mb:"II:VehicleWorkshop"}|
-Industrial progress brings new means of transportation, replacing traditional ones, like horses. The Vehicle Workshop enables you to create these new means, most notably the [Motor Bike](motor_bike.md). To form it, use a hammer on the left aluminium scaffolding.
+Industrial progress brings new means of transportation. The Vehicle Workshop enables you to create these new means, most notably the [Motor Bike](motor_bike.md). To form it, use a [Hammer](introduction#introductionHammer) on the left aluminium scaffolding.
 
 # making_vehicles
-The machine requires **Petroleum**, **Diesel** or **Biodiesel** along with electricity to run, these can be provided using the appropriate ports on machine's side and top. To create a vehicle - select an appropriate option through the interface, provide shown materials and make sure no vehicle is parked on the platform. If all the conditions are met, press the striped button in the interface and the workshop will start assembling your vehicle.
+The machine requires **Petroleum**, **Diesel** or **Biodiesel** along with electricity to run. These can be provided using the appropriate ports on machine's side and top. To create a vehicle, select an appropriate option through the interface, provide shown materials and make sure no vehicle is parked on the platform. If all the conditions are met, press the striped button in the interface and the workshop will start assembling your vehicle.
 
 # fuel
 If the vehicle uses fuel, it will be refueled half-way using the workshop's internal tank. The fuel will not last for long, so consider building a [Fuel Station](fuel_station.md).
 
 # upgrades
-Existing vehicles can also be upgraded. To apply an upgrade, drive your vehicle onto the platform and select valid upgrades through the interface. Upgrading and removing upgrades requires power and diesel to be supplied.
+Vehicles can also be upgraded. To apply an upgrade, drive your vehicle onto the platform and select valid upgrades through the interface. Upgrading and removing upgrades requires a supply of power and diesel.
 

--- a/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_motorworks/vulcanizer.md
+++ b/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_motorworks/vulcanizer.md
@@ -4,17 +4,19 @@ The Overengineered Smoke Dispenser
 
 # intro
 |[multiblock]{mb:"II:Vulcanizer"}|
-The Vulcanizer is the final machine in the [Rubber Production](rubber_production.md) process. To form it use a hammer on the steel block nearest to the tank.
+The Vulcanizer is the final machine in the [Rubber Production](rubber_production.md) process. To form it use a [Hammer](introduction#introductionHammer) on the steel block nearest to the tank.
 
 # production
-Using heat, pressure, molds and set of additional compounds, the Vulcanizer transforms raw rubber sheets into a familiar industrial rubber, which is used to construct many new machines, most notably faster conveyors, more efficient motor belts and is vital to wheeled vehicle production. To process rubber 3 ingredients are required: raw rubber sheets, provided to the upper port on the iron container, vulcanization compound - provided to the port below and sulfur - inputted into the steel tank.
+Using heat, pressure, [molds], and set of additional compounds, the [Vulcanizer] transforms raw rubber sheets into a familiar industrial rubber, which is used to construct many new machines. Most notably, rubber is used to fabricate faster conveyors and more efficient motor belts, and is vital to wheeled vehicle production.
+
+#production2
+To process rubber, 3 ingredients are required: [raw rubber sheets], provided to the upper port on the iron container, [vulcanization compound](#vulcanizer_compounds) - provided to the port below, and [sulfur] - inputted into the steel tank.
 
 # molds
 To operate the machine, the vulcanizer requires a mold, which determines the final output and electricity usage.
 |[crafting]{source:"vulcanizer_blueprint"}|
-Vulcanizer molds can be created in the [Engineers Workbench](engineers_workbench.md) using the blueprint above.
+Vulcanizer molds can be created in the [Engineers Workbench](workbench) using the blueprint above.
 
-# vulcanizer compounds
-|[crafting]{source:"compound"}
-|[crafting]{source:"compound_silicon"}
-The Vulcanization compound consists of additives which improve rubber's properties. It can be crafted in 2 ways.
+# vulcanizer_compounds
+|[crafting]{source:"compound"}|
+The Vulcanization compound consists of additives which improve rubber's properties. It can be crafted in 2 ways: with two [coke dust] and one [silicon dust], or two [coke dust] with a [zinc grit] and a [steel grit].

--- a/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_motorworks/vulcanizer.md
+++ b/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_motorworks/vulcanizer.md
@@ -10,7 +10,7 @@ The Vulcanizer is the final machine in the [Rubber Production](rubber_production
 Using heat, pressure, [molds], and set of additional compounds, the [Vulcanizer] transforms raw rubber sheets into a familiar industrial rubber, which is used to construct many new machines. Most notably, rubber is used to fabricate faster conveyors and more efficient motor belts, and is vital to wheeled vehicle production.
 
 #production2
-To process rubber, 3 ingredients are required: [raw rubber sheets], provided to the upper port on the iron container, [vulcanization compound](#vulcanizer_compounds) - provided to the port below, and [sulfur] - inputted into the steel tank.
+To process rubber, 3 ingredients are required: [raw rubber sheets], provided to the upper port on the iron container, [vulcanization compound](#vulcanizer_compounds), provided to the port below, and [sulfur], inputted into the steel tank.
 
 # molds
 To operate the machine, the vulcanizer requires a mold, which determines the final output and electricity usage.

--- a/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_other/contributor_skins.md
+++ b/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_other/contributor_skins.md
@@ -1,8 +1,0 @@
-# meta
-Contributor Skins
-For Support of Engineered Cause!
-
-# intro
-Contributors of Immersive Intelligence, whether through direct help by providing assets, code, translations, recording tutorial videos, donations through Patreon or simply contributing to II community, can not be overlooked and have to be rewarded.
-For that, a collection of skins has been added to the game, these are applicable to various weapons, ranging from machineguns to howitzers. Huge thanks to all of you, without you this project would take much longer than Soon™.
-

--- a/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_other/electric_tools.md
+++ b/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_other/electric_tools.md
@@ -3,6 +3,13 @@ Electric Tools
 Work smarter, not harder
 
 # intro
-The Engineer's Electric Hammer is a direct upgrade to the old Engineer's Hammer. Due to it's improved strength and speed, this hammer can form and construct Advanced Multiblocks, such as the [Radio Station](radio_station.md).
-The Engineer's Electric Wrench is an enhanced version of the Engineer's Wrench. It constructs upgrades and emplacement weapons much faster than its manual counterpart.
-The Engineer's Electric Wire Cutters are an improved version of the Engineer's Wire Cutters. They cut through blocks, such as razor wire faster.
+|[crafting]{source:"e_hammer"}|
+The Engineer's Electric Hammer is a direct upgrade to the old [Engineer's Hammer](introduction#introductionHammer). Due to it's improved strength and speed, this hammer can form and construct [Advanced Multiblocks], such as the [Radio Station](radio_station.md).
+
+# wrench 
+|[crafting]{source:"e_wrench"}|
+The Engineer's Electric Wrench is an enhanced version of the Engineer's Wrench. It constructs upgrades and emplacement weapons much faster than its manual counterpart. [Some machines cannot be upgraded] without the [electric wrench].
+
+# cutter
+|[crafting]{source:"e_cutter"}|
+The Engineer's Electric Wire Cutters are an improved version of the [Engineer's Wire Cutters](wiring#wiringCutters). They can cut through blocks (such as [razor wire](razorwire)) faster.

--- a/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_other/lighter.md
+++ b/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_other/lighter.md
@@ -3,6 +3,7 @@ Engineer's Lighter
 No Rainbow-Vision
 
 # intro
-The Engineer's Lighter is a device used to set blocks on fire. It has infinite durability, but requires fuel to operate.
+|[crafting]{source:"lighter"}|
+The Engineer's Lighter is a device used to set blocks on fire. It has infinite durability, but requires fuel (such as [diesel] or [biodiesel]) to operate.
 
 

--- a/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_other/measuring_cup.md
+++ b/src/main/resources/assets/immersiveintelligence/ie_manual/en_us/ii_other/measuring_cup.md
@@ -1,7 +1,7 @@
 # meta
-Measuring cup
+Measuring Cup
 The Bakers Special
 
 # intro
-This section is currently a Work In Progress, please excuse our dust!
-
+|[crafting]{source:"m_cup"}|
+The Measuring Cup is a simple, but powerful tool for the crafty chemical engineer. It has a maximum 500mb capacity, but [sneaking] and [scrolling] will allow changing the capacity in [10mb increments]. This allows for precise fluid collection from containers.


### PR DESCRIPTION
Intel:
Full grammar and writing sweep, add missing strategic table page but ensure it is marked as WIP. Added links to most pages. Fixed infrared crafting recipe.

Motorworks:
Full grammar and writing sweep. Rearranged subpage order. Added links to most pages. Fixed crafting recipes for vulcanizer compound. **Note: Vehicle Workshop page still crashes the game when it's opened. Seems like a regression of #300**

Other:
Restores Other category to its former glory. Adds recipes for each entry. Grammar sweep and info update, especially for measuring cup. Moves skins page to Other category instead of Weapons. Fixes contributor skins title. Adds flavour text from old contributor_skins.md.