### PR TITLE
Fixes Redstone Data Interface IO

### DIFF
--- a/src/main/java/pl/pabilo8/immersiveintelligence/common/block/multiblock/metal_multiblock1/tileentity/TileEntityRedstoneDataInterface.java
+++ b/src/main/java/pl/pabilo8/immersiveintelligence/common/block/multiblock/metal_multiblock1/tileentity/TileEntityRedstoneDataInterface.java
@@ -8,6 +8,7 @@ import blusunrize.immersiveengineering.api.energy.wires.redstone.RedstoneWireNet
 import net.minecraft.item.EnumDyeColor;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.EnumFacing;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3d;
@@ -41,7 +42,7 @@ import java.util.Objects;
 
 /**
  * @author Pabilo8 (pabilo@iiteam.net)
- * @updated 09.03.2026
+ * @updated 01.04.2026
  * @ii-approved 0.3.1
  * @since 28.06.2019
  */
@@ -79,6 +80,9 @@ public class TileEntityRedstoneDataInterface extends TileEntityMultiblockIIConne
 	}
 
 	@Override
+	public void onChange() {}
+
+	@Override
 	protected void onUpdate()
 	{
 		//Progress punchtape reading
@@ -99,7 +103,7 @@ public class TileEntityRedstoneDataInterface extends TileEntityMultiblockIIConne
 			{
 				inventory.set(MultiblockRedstoneInterface.SLOT_PUNCHTAPE_OUTPUT, processPunchtape(punchtapeRedstone, redstoneSettings));
 				inventory.set(MultiblockRedstoneInterface.SLOT_PUNCHTAPE_REDSTONE, ItemStack.EMPTY);
-				reactToRedstoneChange();
+				reactToRedstoneChange(null);
 			}
 			else if(!punchtapeData.isEmpty())
 			{
@@ -146,7 +150,7 @@ public class TileEntityRedstoneDataInterface extends TileEntityMultiblockIIConne
 		{
 			case REDSTONE_CABLE_MOUNT:
 				return getPOI("redstone");
-			case DATA:
+			case DATA_INPUT:
 				return getPOI("data");
 			default:
 				return new int[0];
@@ -182,26 +186,26 @@ public class TileEntityRedstoneDataInterface extends TileEntityMultiblockIIConne
 			master.redstoneNetwork.setNetwork(net);
 	}
 
-	@Override
-	public void onChange()
-	{
-		TileEntityRedstoneDataInterface master = master();
-		if(master!=null)
-			master.reactToRedstoneChange();
-	}
-
-	private void reactToRedstoneChange()
+	private void reactToRedstoneChange(byte[] signals)
 	{
 		DataPacket packet = new DataPacket();
 		//Go through all the redstone->data conversion rules
 		for(ConversionSetting setting : dataSettings)
 		{
-			byte value = redstoneOutput[setting.getColor().getMetadata()];
+			byte value;
+			if (signals == null) {
+				value = redstoneOutput[setting.getColor().getMetadata()];
+			} else {
+				value = signals[setting.getColor().getMetadata()];
+			}
 			packet.set(setting.getVariable(), setting.getDataFromRedstone(value));
+
 		}
 		//Send the packet
-		if(!packet.isEmpty())
-			sendData(packet, getDirection("data"), multiblock.getPointOfInterest("data"));
+		if(!packet.isEmpty()){
+			sendData(packet, getDirection("data").getOpposite(), multiblock.getPointOfInterest("data"));
+		}
+
 	}
 
 	@Override
@@ -213,12 +217,13 @@ public class TileEntityRedstoneDataInterface extends TileEntityMultiblockIIConne
 	@Override
 	public void updateInput(byte[] signals)
 	{
-		TileEntityRedstoneDataInterface m = master();
-		if(m!=null)
+		TileEntityRedstoneDataInterface master = master();
+		if(master!=null) {
 			for(int i = 0; i < 16; i += 1)
-				if(signals[i] < m.redstoneOutput[i])
-					signals[i] = m.redstoneOutput[i];
-
+				if(signals[i] < master.redstoneOutput[i])
+					signals[i] = master.redstoneOutput[i];
+			master.reactToRedstoneChange(signals);
+		}
 	}
 
 	@Override
@@ -230,7 +235,22 @@ public class TileEntityRedstoneDataInterface extends TileEntityMultiblockIIConne
 	@Override
 	public Vec3d getConnectionOffset(Connection con)
 	{
-		return new Vec3d(0.5f, 0.5f, 0.5f);
+		EnumFacing direction = getDirection("data");
+		double x = 0.5;
+		double z = 0.5;
+
+		if (direction != null)
+		{
+			// We just make the assumption, that the data connector is always on the opposite side.
+			switch(direction)
+			{
+				case NORTH: x += mirrored ? 0.125 : -0.125; break;
+				case SOUTH: x += mirrored ? -0.125 : 0.125;break;
+				case EAST: z += mirrored ? 0.125 : -0.125;break;
+				case WEST: z += mirrored ? -0.125 : 0.125;break;
+			}
+		}
+		return new Vec3d(x, 0.75f, z);
 	}
 
 	@Override

--- a/src/main/java/pl/pabilo8/immersiveintelligence/common/block/multiblock/metal_multiblock1/tileentity/TileEntityRedstoneDataInterface.java
+++ b/src/main/java/pl/pabilo8/immersiveintelligence/common/block/multiblock/metal_multiblock1/tileentity/TileEntityRedstoneDataInterface.java
@@ -75,7 +75,6 @@ public class TileEntityRedstoneDataInterface extends TileEntityMultiblockIIConne
 	@Override
 	protected void dummyCleanup()
 	{
-
 		this.dataSettings = this.redstoneSettings = null;
 		this.inventory = null;
 		this.redstoneNetwork = null;
@@ -84,7 +83,10 @@ public class TileEntityRedstoneDataInterface extends TileEntityMultiblockIIConne
 	}
 
 	@Override
-	public void onChange() {}
+	public void onChange() 
+	{
+		
+	}
 
 	@Override
 	protected void onUpdate()
@@ -195,10 +197,14 @@ public class TileEntityRedstoneDataInterface extends TileEntityMultiblockIIConne
 	{
 
 		// Filter duplicate signals from the Restone Network, in particular when the restone network is updating
-		if (signals != null) {
-			if (!Arrays.equals(signals, this.recentSignals)) {
+		if (signals != null)
+		{
+			if (!Arrays.equals(signals, this.recentSignals))
+			{
 				this.recentSignals = signals;
-			} else {
+			} 
+			else
+			{
 				return;
 			}
 		}
@@ -208,9 +214,12 @@ public class TileEntityRedstoneDataInterface extends TileEntityMultiblockIIConne
 		for(ConversionSetting setting : dataSettings)
 		{
 			byte value;
-			if (signals == null) {
+			if (signals == null)
+			{
 				value = redstoneOutput[setting.getColor().getMetadata()];
-			} else {
+			} 
+			else
+			{
 				value = signals[setting.getColor().getMetadata()];
 			}
 			packet.set(setting.getVariable(), setting.getDataFromRedstone(value));

--- a/src/main/java/pl/pabilo8/immersiveintelligence/common/block/multiblock/metal_multiblock1/tileentity/TileEntityRedstoneDataInterface.java
+++ b/src/main/java/pl/pabilo8/immersiveintelligence/common/block/multiblock/metal_multiblock1/tileentity/TileEntityRedstoneDataInterface.java
@@ -37,6 +37,7 @@ import pl.pabilo8.immersiveintelligence.common.util.multiblock.util.MultiblockPO
 import pl.pabilo8.immersiveintelligence.common.util.multiblock.util.MultiblockRedstoneNetwork;
 
 import javax.annotation.Nonnull;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Objects;
 
@@ -60,6 +61,7 @@ public class TileEntityRedstoneDataInterface extends TileEntityMultiblockIIConne
 	protected MultiblockRedstoneNetwork<TileEntityRedstoneDataInterface> redstoneNetwork;
 
 	byte[] redstoneOutput = new byte[16];
+	byte[] recentSignals = new byte[16]; // For duplicate detection
 
 	public TileEntityRedstoneDataInterface()
 	{
@@ -73,10 +75,12 @@ public class TileEntityRedstoneDataInterface extends TileEntityMultiblockIIConne
 	@Override
 	protected void dummyCleanup()
 	{
+
 		this.dataSettings = this.redstoneSettings = null;
 		this.inventory = null;
 		this.redstoneNetwork = null;
 		this.redstoneOutput = null;
+		this.recentSignals = null;
 	}
 
 	@Override
@@ -184,10 +188,21 @@ public class TileEntityRedstoneDataInterface extends TileEntityMultiblockIIConne
 		TileEntityRedstoneDataInterface master = master();
 		if(master!=null)
 			master.redstoneNetwork.setNetwork(net);
+		else redstoneNetwork.setNetwork(net);
 	}
 
 	private void reactToRedstoneChange(byte[] signals)
 	{
+
+		// Filter duplicate signals from the Restone Network, in particular when the restone network is updating
+		if (signals != null) {
+			if (!Arrays.equals(signals, this.recentSignals)) {
+				this.recentSignals = signals;
+			} else {
+				return;
+			}
+		}
+
 		DataPacket packet = new DataPacket();
 		//Go through all the redstone->data conversion rules
 		for(ConversionSetting setting : dataSettings)


### PR DESCRIPTION
I made a few changes in the Redstone Data Interface Tile Entity file.
The changes are the following:
* Data I/O now works again. The TE receives Data from the Data System again and can send into it.
* Redstone I/O works again aswell. The TE receives Redstone Signal and can set it on the IE Bundled Cable.
* Redstone Cables connect correctly to Connector of the Redstone Data Interface
* Fixed Bug, where after forming the Multiblock the Redstone Network needed an extra Update to work.
* added Optimization, where multiple Redstone Network Updates now only generate Data Packages, if the Signals actually changes.

Note:
There is currently some weirdness going on with the orientation of the Data Connector. The workaround here for now is to reverse the facing direction, which fixed it for the time being.

After that PR, what could be useful, is implementing some sort of reset logic, whenever the Redstone conversion Entries change. And switch around the Display of the Entries within the RedstoneSettings and DataSettings Tabs.