### PR TITLE
Fix Client Crash when building RedstoneDataInterface Multiblock

### DIFF
--- a/src/main/java/pl/pabilo8/immersiveintelligence/common/util/multiblock/TileEntityMultiblockIIBase.java
+++ b/src/main/java/pl/pabilo8/immersiveintelligence/common/util/multiblock/TileEntityMultiblockIIBase.java
@@ -500,27 +500,12 @@ public abstract class TileEntityMultiblockIIBase<T extends TileEntityMultiblockI
 
 	public UUID getUUID()
 	{
-		if(isDummy())
+		if(this.uuid==null)
 		{
-			T master = master();
-			if (master == null)
-			{
-				return IIUtils.getBlockPosUUID(getPos());
-			} else
-			{
-				if (world.isRemote)
-				{
-					return master.uuid;
-				} else
-				{
-					return master.getUUID();
-				}
-
-			}
-		}
-		if (this.uuid == null)
-		{
-			this.uuid = IIUtils.getBlockPosUUID(getPos());
+			UUID uuid = IIUtils.getBlockPosUUID(getPos().add(-offset[0], -offset[1], -offset[2]));
+			if(master!=null)
+				this.uuid = uuid; //Master exists, so the position is correct
+			return uuid;
 		}
 		return this.uuid;
 	}

--- a/src/main/java/pl/pabilo8/immersiveintelligence/common/util/multiblock/TileEntityMultiblockIIBase.java
+++ b/src/main/java/pl/pabilo8/immersiveintelligence/common/util/multiblock/TileEntityMultiblockIIBase.java
@@ -503,9 +503,16 @@ public abstract class TileEntityMultiblockIIBase<T extends TileEntityMultiblockI
 		if(isDummy())
 		{
 			T master = master();
-			return master==null?IIUtils.getBlockPosUUID(getPos()): master.getUUID();
+			if (master == null) {
+				return IIUtils.getBlockPosUUID(getPos());
+			} else {
+				return master.uuid;
+			}
 		}
-		return this.uuid==null?this.uuid = IIUtils.getBlockPosUUID(getPos()): this.uuid;
+		if (this.uuid == null) {
+			this.uuid = IIUtils.getBlockPosUUID(getPos());
+		}
+		return this.uuid;
 	}
 
 	public long getTicksExisted()

--- a/src/main/java/pl/pabilo8/immersiveintelligence/common/util/multiblock/TileEntityMultiblockIIBase.java
+++ b/src/main/java/pl/pabilo8/immersiveintelligence/common/util/multiblock/TileEntityMultiblockIIBase.java
@@ -506,7 +506,12 @@ public abstract class TileEntityMultiblockIIBase<T extends TileEntityMultiblockI
 			if (master == null) {
 				return IIUtils.getBlockPosUUID(getPos());
 			} else {
-				return master.uuid;
+				if (world.isRemote) {
+					return master.uuid;
+				} else {
+					return master.getUUID();
+				}
+
 			}
 		}
 		if (this.uuid == null) {

--- a/src/main/java/pl/pabilo8/immersiveintelligence/common/util/multiblock/TileEntityMultiblockIIBase.java
+++ b/src/main/java/pl/pabilo8/immersiveintelligence/common/util/multiblock/TileEntityMultiblockIIBase.java
@@ -503,18 +503,23 @@ public abstract class TileEntityMultiblockIIBase<T extends TileEntityMultiblockI
 		if(isDummy())
 		{
 			T master = master();
-			if (master == null) {
+			if (master == null)
+			{
 				return IIUtils.getBlockPosUUID(getPos());
-			} else {
-				if (world.isRemote) {
+			} else
+			{
+				if (world.isRemote)
+				{
 					return master.uuid;
-				} else {
+				} else
+				{
 					return master.getUUID();
 				}
 
 			}
 		}
-		if (this.uuid == null) {
+		if (this.uuid == null)
+		{
 			this.uuid = IIUtils.getBlockPosUUID(getPos());
 		}
 		return this.uuid;


### PR DESCRIPTION
This PR fixes https://github.com/Team-Immersive-Intelligence/ImmersiveIntelligence/issues/554

The code that caused the crash was a runaway recursion, that was probably caused somewhere else in the code, prompting essentially an infinite recursion of `master.getUUID()` on the Client.

**_I need some Opinions on how it is solved though, since the change is potentially risky._**
I have tested some Multiblocks in Singleplayer and Multiplayer and they seem to be working.
If we have any known TileEntities that would break under these circumstances, i can address them with this PR (to fix it all in one go)

I will see in the meantime, if i can find something, that would break with this change, and report here.